### PR TITLE
WIP-  correcao acesso login existente

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
         minSdk 24
         targetSdk 35
         versionCode 4
-        versionName "1.4.5"
+        versionName "1.4.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -60,7 +60,7 @@ android {
             resValue "string","interstitial_ad_unit_id","ca-app-pub-3940256099942544/1033173712"
         }
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),'proguard-rules.pro'
 
             def interactAdKeyRelease = getLocalProperty("INTERACT_AD_kEY", project)

--- a/app/src/main/java/com/example/afimdefeirax/ViewModel/LoginViewModel.kt
+++ b/app/src/main/java/com/example/afimdefeirax/ViewModel/LoginViewModel.kt
@@ -21,6 +21,7 @@ class LoginViewModel(
     skipInit: Boolean = false
 ) : ViewModel() {
 
+    private val messageUserAlreadyRegistered ="The email address is already in use by another account."
     private val _state: MutableStateFlow<LoginUiState> = MutableStateFlow(LoginUiState())
     val state: StateFlow<LoginUiState> = _state
 
@@ -87,13 +88,15 @@ class LoginViewModel(
 
         } catch (error: Exception) {
 
-            _state.update { it.copy(isLoading = false, error = Monitoring.Login.LOGIN_FAILED) }
-            analyticservice.firebaselogEvent(Monitoring.Login.LOGIN_FAILED)
-            Log.e(Monitoring.Login.LOGIN_FAILED, error.message.toString())
-            result = false
+            if (error.message.equals(messageUserAlreadyRegistered)){
+                localSave()
+                return onlogin()
+            }
+                _state.update { it.copy(isLoading = false, error = Monitoring.Login.LOGIN_FAILED) }
+                analyticservice.firebaselogEvent(Monitoring.Login.LOGIN_FAILED)
+                Log.e(Monitoring.Login.LOGIN_FAILED, error.message.toString())
+                result = false
         }
-
-
         return result
     }
 


### PR DESCRIPTION
#  Merge RequesFix

## Qual foi o problema?
        
- correção para os casos onde o usuário já existente faz login em outro celular ou depois de apagar cache.

- que foi feito

~~~Kotlint 

        } catch (error: Exception) {

            if (error.message.equals(messageUserAlreadyRegistered)){
                localSave()
                return onlogin()
            }
                _state.update { it.copy(isLoading = false, error = Monitoring.Login.LOGIN_FAILED) }
                analyticservice.firebaselogEvent(Monitoring.Login.LOGIN_FAILED)
                Log.e(Monitoring.Login.LOGIN_FAILED, error.message.toString())
                result = false
        }
        return result
    }
        
~~~